### PR TITLE
Add dropdown for game age filtering.

### DIFF
--- a/cockatrice/src/dlg_filter_games.cpp
+++ b/cockatrice/src/dlg_filter_games.cpp
@@ -1,6 +1,7 @@
 #include "dlg_filter_games.h"
 
 #include <QCheckBox>
+#include <QComboBox>
 #include <QCryptographicHash>
 #include <QDialogButtonBox>
 #include <QGridLayout>
@@ -29,6 +30,13 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     hideIgnoredUserGames = new QCheckBox(tr("Hide '&ignored user' games"));
     hideIgnoredUserGames->setChecked(gamesProxyModel->getHideIgnoredUserGames());
 
+    maxGameAgeComboBox = new QComboBox();
+    maxGameAgeComboBox->setEditable(false);
+    maxGameAgeComboBox->addItems(gamesProxyModel->getMaxGameAgeOptions());
+    maxGameAgeComboBox->setCurrentIndex((int)gamesProxyModel->getMaxGameAge());
+    QLabel *maxGameAgeLabel = new QLabel(tr("Hide games &older than:"));
+    maxGameAgeLabel->setBuddy(maxGameAgeComboBox);
+
     gameNameFilterEdit = new QLineEdit;
     gameNameFilterEdit->setText(gamesProxyModel->getGameNameFilter());
     QLabel *gameNameFilterLabel = new QLabel(tr("Game &description:"));
@@ -43,6 +51,8 @@ DlgFilterGames::DlgFilterGames(const QMap<int, QString> &_allGameTypes,
     generalGrid->addWidget(gameNameFilterEdit, 0, 1);
     generalGrid->addWidget(creatorNameFilterLabel, 1, 0);
     generalGrid->addWidget(creatorNameFilterEdit, 1, 1);
+    generalGrid->addWidget(maxGameAgeLabel, 2, 0);
+    generalGrid->addWidget(maxGameAgeComboBox, 2, 1);
     generalGroupBox = new QGroupBox(tr("General"));
     generalGroupBox->setLayout(generalGrid);
 
@@ -218,6 +228,11 @@ int DlgFilterGames::getMaxPlayersFilterMin() const
 int DlgFilterGames::getMaxPlayersFilterMax() const
 {
     return maxPlayersFilterMaxSpinBox->value();
+}
+
+int DlgFilterGames::getMaxGameAgeAsInt() const
+{
+    return maxGameAgeComboBox->currentIndex();
 }
 
 void DlgFilterGames::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax)

--- a/cockatrice/src/dlg_filter_games.h
+++ b/cockatrice/src/dlg_filter_games.h
@@ -4,11 +4,13 @@
 #include "gamesmodel.h"
 
 #include <QCheckBox>
+#include <QComboBox>
 #include <QDialog>
 #include <QMap>
 #include <QSet>
 
 class QCheckBox;
+class QComboBox;
 class QGroupBox;
 class QLineEdit;
 class QSpinBox;
@@ -27,6 +29,7 @@ private:
     QMap<int, QCheckBox *> gameTypeFilterCheckBoxes;
     QSpinBox *maxPlayersFilterMinSpinBox;
     QSpinBox *maxPlayersFilterMaxSpinBox;
+    QComboBox *maxGameAgeComboBox;
 
     const QMap<int, QString> &allGameTypes;
     const GamesProxyModel *gamesProxyModel;
@@ -56,6 +59,7 @@ public:
     int getMaxPlayersFilterMin() const;
     int getMaxPlayersFilterMax() const;
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
+    int getMaxGameAgeAsInt() const;
 };
 
 #endif

--- a/cockatrice/src/gameselector.cpp
+++ b/cockatrice/src/gameselector.cpp
@@ -163,6 +163,7 @@ void GameSelector::actSetFilter()
     gameListProxyModel->setCreatorNameFilter(dlg.getCreatorNameFilter());
     gameListProxyModel->setGameTypeFilter(dlg.getGameTypeFilter());
     gameListProxyModel->setMaxPlayersFilter(dlg.getMaxPlayersFilterMin(), dlg.getMaxPlayersFilterMax());
+    gameListProxyModel->setMaxGameAge(dlg.getMaxGameAgeAsInt());
     gameListProxyModel->saveFilterParameters(gameTypeMap);
 
     clearFilterButton->setEnabled(!gameListProxyModel->areFilterParametersSetToDefaults());

--- a/cockatrice/src/gamesmodel.cpp
+++ b/cockatrice/src/gamesmodel.cpp
@@ -23,7 +23,7 @@ enum GameListColumn
     SPECTATORS
 };
 
-const QString GamesModel::getGameCreatedString(const int secs) const
+const QString GamesModel::getGameCreatedString(const int secs)
 {
 
     QString ret;
@@ -260,8 +260,8 @@ GamesProxyModel::GamesProxyModel(QObject *parent, const TabSupervisor *_tabSuper
     : QSortFilterProxyModel(parent), ownUserIsRegistered(_tabSupervisor->isOwnUserRegistered()),
       tabSupervisor(_tabSupervisor), showBuddiesOnlyGames(DEFAULT_SHOW_BUDDIES_ONLY_GAMES),
       hideIgnoredUserGames(DEFAULT_HIDE_IGNORED_USER_GAMES), unavailableGamesVisible(DEFAULT_UNAVAILABLE_GAMES_VISIBLE),
-      showPasswordProtectedGames(DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES), maxPlayersFilterMin(MAX_PLAYERS_FILTER_OFF),
-      maxPlayersFilterMax(MAX_PLAYERS_FILTER_OFF)
+      showPasswordProtectedGames(DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES), maxPlayersFilterMin(SPINBOX_OR_COMBOBOX_OFF),
+      maxPlayersFilterMax(SPINBOX_OR_COMBOBOX_OFF), maxGameAge(DEFAULT_MAX_GAME_AGE)
 {
     setSortRole(GamesModel::SORT_ROLE);
     setDynamicSortFilter(true);
@@ -316,6 +316,46 @@ void GamesProxyModel::setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlay
     invalidateFilter();
 }
 
+void GamesProxyModel::setMaxGameAge(const int _maxGameAge)
+{
+    maxGameAge = static_cast<MaxGameAge>(_maxGameAge);
+    invalidateFilter();
+}
+
+int GamesProxyModel::getMaxGameAgeInSeconds(MaxGameAge maxGameAge)
+{
+    switch (maxGameAge)
+    {
+        case FIVE_MINUTES:
+            return 5 * SECS_PER_MIN;
+        case TEN_MINUTES:
+            return 10 * SECS_PER_MIN;
+        case THIRTY_MINUTES:
+            return 30 * SECS_PER_MIN;
+        case ONE_HOUR:
+            return 1 * SECS_PER_HOUR;
+        case TWO_HOURS:
+            return 2 * SECS_PER_HOUR;
+        default:
+            return -1;
+    }
+}
+
+const QStringList GamesProxyModel::getMaxGameAgeOptions()
+{
+    QStringList gameAgeList;
+    const auto ageEnumList = {FIVE_MINUTES, TEN_MINUTES, THIRTY_MINUTES, ONE_HOUR, TWO_HOURS};
+    gameAgeList.reserve(ageEnumList.size() + 1);
+    gameAgeList.append(tr("No max age"));
+    for (MaxGameAge maxAge : ageEnumList)
+    {
+        const int maxAgeSeconds = getMaxGameAgeInSeconds(maxAge);
+        if (maxAgeSeconds != -1)
+            gameAgeList.append(GamesModel::getGameCreatedString(maxAgeSeconds));
+    }
+    return gameAgeList;
+}
+
 int GamesProxyModel::getNumFilteredGames() const
 {
     GamesModel *model = qobject_cast<GamesModel *>(sourceModel());
@@ -342,6 +382,7 @@ void GamesProxyModel::resetFilterParameters()
     gameTypeFilter.clear();
     maxPlayersFilterMin = DEFAULT_MAX_PLAYERS_MIN;
     maxPlayersFilterMax = DEFAULT_MAX_PLAYERS_MAX;
+    maxGameAge = DEFAULT_MAX_GAME_AGE;
 
     invalidateFilter();
 }
@@ -353,8 +394,9 @@ bool GamesProxyModel::areFilterParametersSetToDefaults() const
            showBuddiesOnlyGames == DEFAULT_SHOW_BUDDIES_ONLY_GAMES &&
            hideIgnoredUserGames == DEFAULT_HIDE_IGNORED_USER_GAMES && gameNameFilter.isEmpty() &&
            creatorNameFilter.isEmpty() && gameTypeFilter.isEmpty() &&
-           (maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN || maxPlayersFilterMin == MAX_PLAYERS_FILTER_OFF) &&
-           (maxPlayersFilterMax == DEFAULT_MAX_PLAYERS_MAX || maxPlayersFilterMax == MAX_PLAYERS_FILTER_OFF);
+           (maxPlayersFilterMin == DEFAULT_MAX_PLAYERS_MIN || maxPlayersFilterMin == SPINBOX_OR_COMBOBOX_OFF) &&
+           (maxPlayersFilterMax == DEFAULT_MAX_PLAYERS_MAX || maxPlayersFilterMax == SPINBOX_OR_COMBOBOX_OFF) &&
+           maxGameAge == DEFAULT_MAX_GAME_AGE;
 }
 
 void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameTypes)
@@ -366,6 +408,7 @@ void GamesProxyModel::loadFilterParameters(const QMap<int, QString> &allGameType
     gameNameFilter = gameFilters.getGameNameFilter();
     maxPlayersFilterMin = gameFilters.getMinPlayers();
     maxPlayersFilterMax = gameFilters.getMaxPlayers();
+    maxGameAge = static_cast<MaxGameAge>(gameFilters.getMaxGameAgeEnum());
 
     QMapIterator<int, QString> gameTypesIterator(allGameTypes);
     while (gameTypesIterator.hasNext()) {
@@ -396,6 +439,7 @@ void GamesProxyModel::saveFilterParameters(const QMap<int, QString> &allGameType
 
     gameFilters.setMinPlayers(maxPlayersFilterMin);
     gameFilters.setMaxPlayers(maxPlayersFilterMax);
+    gameFilters.setMaxGameAgeAsInt((int)maxGameAge);
 }
 
 bool GamesProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex & /*sourceParent*/) const
@@ -442,11 +486,19 @@ bool GamesProxyModel::filterAcceptsRow(int sourceRow) const
     if (!gameTypeFilter.isEmpty() && gameTypes.intersect(gameTypeFilter).isEmpty())
         return false;
 
-    if ((maxPlayersFilterMin != MAX_PLAYERS_FILTER_OFF) && ((int)game.max_players() < maxPlayersFilterMin))
+    if ((maxPlayersFilterMin != SPINBOX_OR_COMBOBOX_OFF) && ((int)game.max_players() < maxPlayersFilterMin))
         return false;
-    if ((maxPlayersFilterMax != MAX_PLAYERS_FILTER_OFF) && ((int)game.max_players() > maxPlayersFilterMax))
+    if ((maxPlayersFilterMax != SPINBOX_OR_COMBOBOX_OFF) && ((int)game.max_players() > maxPlayersFilterMax))
         return false;
 
+    const int maxAgeSeconds = getMaxGameAgeInSeconds(maxGameAge);
+    if (maxAgeSeconds != -1)
+    {
+        QDateTime then;
+        then.setTime_t(game.start_time());
+        if (then.secsTo(QDateTime::currentDateTime()) > maxAgeSeconds)
+            return false;
+    }
     return true;
 }
 

--- a/cockatrice/src/gamesmodel.h
+++ b/cockatrice/src/gamesmodel.h
@@ -9,6 +9,7 @@
 #include <QList>
 #include <QSet>
 #include <QSortFilterProxyModel>
+#include <QStringList>
 
 class GamesModel : public QAbstractTableModel
 {
@@ -37,7 +38,7 @@ public:
     }
     QVariant data(const QModelIndex &index, int role) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-    const QString getGameCreatedString(const int secs) const;
+    static const QString getGameCreatedString(const int secs);
     const ServerInfo_Game &getGame(int row);
 
     /**
@@ -62,12 +63,30 @@ public:
 
 class ServerInfo_User;
 
+enum MaxGameAge
+{
+    NO_MAX_AGE = 0,
+    FIVE_MINUTES = 1,
+    TEN_MINUTES = 2,
+    THIRTY_MINUTES = 3,
+    ONE_HOUR = 4,
+    TWO_HOURS = 5
+};
+
 class GamesProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 private:
     bool ownUserIsRegistered;
     const TabSupervisor *tabSupervisor;
+
+    // If adding any additional filters, make sure to update:
+    // - GamesProxyModel()
+    // - resetFilterParameters()
+    // - areFilterParametersSetToDefaults()
+    // - loadFilterParameters()
+    // - saveFilterParameters()
+    // - filterAcceptsRow()
     bool showBuddiesOnlyGames;
     bool hideIgnoredUserGames;
     bool unavailableGamesVisible;
@@ -75,14 +94,19 @@ private:
     QString gameNameFilter, creatorNameFilter;
     QSet<int> gameTypeFilter;
     int maxPlayersFilterMin, maxPlayersFilterMax;
+    MaxGameAge maxGameAge;
 
     static const bool DEFAULT_UNAVAILABLE_GAMES_VISIBLE = false;
     static const bool DEFAULT_SHOW_PASSWORD_PROTECTED_GAMES = true;
     static const bool DEFAULT_SHOW_BUDDIES_ONLY_GAMES = true;
     static const bool DEFAULT_HIDE_IGNORED_USER_GAMES = false;
-    static const int MAX_PLAYERS_FILTER_OFF = -1;
+    static const int SPINBOX_OR_COMBOBOX_OFF = -1;
     static const int DEFAULT_MAX_PLAYERS_MIN = 1;
     static const int DEFAULT_MAX_PLAYERS_MAX = 99;
+    static const MaxGameAge DEFAULT_MAX_GAME_AGE = TWO_HOURS;
+
+    static const int SECS_PER_MIN = 60;
+    static const int SECS_PER_HOUR = 3600;
 
 public:
     GamesProxyModel(QObject *parent = nullptr, const TabSupervisor *_tabSupervisor = nullptr);
@@ -131,6 +155,14 @@ public:
         return maxPlayersFilterMax;
     }
     void setMaxPlayersFilter(int _maxPlayersFilterMin, int _maxPlayersFilterMax);
+    MaxGameAge getMaxGameAge() const
+    {
+        return maxGameAge;
+    }
+    void setMaxGameAge(int _maxGameAge);
+    static int getMaxGameAgeInSeconds(MaxGameAge maxGameAge);
+    static const QStringList getMaxGameAgeOptions();
+
     int getNumFilteredGames() const;
     void resetFilterParameters();
     bool areFilterParametersSetToDefaults() const;

--- a/cockatrice/src/settings/gamefilterssettings.cpp
+++ b/cockatrice/src/settings/gamefilterssettings.cpp
@@ -92,6 +92,17 @@ int GameFiltersSettings::getMaxPlayers()
     return previous == QVariant() ? 99 : previous.toInt();
 }
 
+void GameFiltersSettings::setMaxGameAgeAsInt(int maxGameAgeEnum)
+{
+    setValue(maxGameAgeEnum, "max_game_age_enum", "filter_games");
+}
+
+int GameFiltersSettings::getMaxGameAgeEnum()
+{
+    QVariant previous = getValue("max_game_age_enum", "filter_games");
+    return previous == QVariant() ? 5 : previous.toInt();
+}
+
 void GameFiltersSettings::setGameTypeEnabled(QString gametype, bool enabled)
 {
     setValue(enabled, "game_type/" + hashGameType(gametype), "filter_games");

--- a/cockatrice/src/settings/gamefilterssettings.h
+++ b/cockatrice/src/settings/gamefilterssettings.h
@@ -16,6 +16,7 @@ public:
     QString getGameNameFilter();
     int getMinPlayers();
     int getMaxPlayers();
+    int getMaxGameAgeEnum();
     bool isGameTypeEnabled(QString gametype);
 
     void setShowBuddiesOnlyGames(bool show);
@@ -25,6 +26,7 @@ public:
     void setGameNameFilter(QString gameName);
     void setMinPlayers(int min);
     void setMaxPlayers(int max);
+    void setMaxGameAgeAsInt(int maxGameAgeEnum);
     void setGameTypeEnabled(QString gametype, bool enabled);
     void setGameHashedTypeEnabled(QString gametypeHASHED, bool enabled);
 signals:


### PR DESCRIPTION
Options include 5/10/30min, 1/2hr, or no filter. Uses same text generation logic as https://github.com/Cockatrice/Cockatrice/blob/master/cockatrice/src/gamesmodel.cpp#L26.

## Related Ticket(s)
- Fixes #3067

## Short roundup of the initial problem
Users don't want to see games that are 2-3 hours old, and it's hard to properly close out such games.

## What will change with this Pull Request?
- Adding a dropdown selection for game age filtering
- Re-using text generation for age filter options in dropdown
- Updates logic that actually filters games
- Sets default filter to remove games 2+ hours old, updating from #4088 to consider 2+ hours the default (e.g. for enabling/disabling "Clear filters" button)

## Screenshots

Can see 2+h is default, and "Clear filters" button remains disabled on cold load:
<img width="946" alt="Screen Shot 2020-09-07 at 9 41 46 PM" src="https://user-images.githubusercontent.com/63179146/92424694-019f0600-f153-11ea-80f5-d2ecb8624eef.png">

Full list of options:
<img width="905" alt="Screen Shot 2020-09-07 at 9 41 55 PM" src="https://user-images.githubusercontent.com/63179146/92424700-0499f680-f153-11ea-8a20-284897b599e5.png">

